### PR TITLE
Remove usage of Path as context manager

### DIFF
--- a/algojig/gojig.py
+++ b/algojig/gojig.py
@@ -14,9 +14,9 @@ binary = f'algojig_{machine}'
 
 
 def run(command, *args, input=None):
-    with importlib.resources.files(algojig).joinpath(binary) as p:
-        output = subprocess.run([p, command, *args], capture_output=True, input=input)
-        return output
+    p = importlib.resources.files(algojig).joinpath(binary)
+    output = subprocess.run([p, command, *args], capture_output=True, input=input)
+    return output
 
 
 def init_ledger(block_timestamp):


### PR DESCRIPTION
Related deprecation message:

```
algojig/gojig.py:17: DeprecationWarning: pathlib.Path.__enter__() is deprecated and scheduled for removal in Python 3.13; Path objects as a context manager is a no-op
  with importlib.resources.files(algojig).joinpath(binary) as p:
```